### PR TITLE
wireguard und docker-ce 

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -5,6 +5,7 @@ users:
   - { name: 'michel', github: 'eriu' }
   - { name: 'sebastian', github: 'bastinat0r' }
   - { name: 'alex', github: 'LeSpocky' }
+  - { name: 'christof', github: 'christf' }
 
 community_tag: 'ffmd'
 fastd_peer_repository: 'git@gw1.md.freifunk.net:fastdpeers.git'

--- a/roles/docker-ce/tasks/apt_unstable.j2
+++ b/roles/docker-ce/tasks/apt_unstable.j2
@@ -1,0 +1,3 @@
+Package: *
+Pin: release a=unstable
+Pin-Priority: 50

--- a/roles/docker-ce/tasks/main.retry
+++ b/roles/docker-ce/tasks/main.retry
@@ -1,0 +1,1 @@
+gw2.md.freifunk.net

--- a/roles/docker-ce/tasks/main.yml
+++ b/roles/docker-ce/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+- tasks:
+  - name: apt-transport-https
+    apt:
+      name: apt-transport-https
+      state: latest
+      update_cache: yes
+  - name: ca-certificates
+    apt:
+      name: ca-certificates
+      state: latest
+  - name: ca-certificates
+    apt:
+      name: curl
+      state: latest
+  - name: gnupg2
+    apt:
+      name: gnupg2
+      state: latest
+  - name: git
+    apt:
+      name: git
+      state: latest
+  - name: software-properties-common
+    apt:
+      name: software-properties-common
+      state: latest
+  - name: Add dockerce repository key
+    apt_key: 
+      url: https://download.docker.com/linux/debian/gpg
+      id: 0EBFCD88
+      state: present
+  - shell: lsb_release -cs
+    register: LSB
+  - name: Add docker-ce repository
+    apt_repository: 
+      repo: deb https://download.docker.com/linux/debian {{ LSB.stdout }} stable
+      state: present
+  - name: install docker
+    apt:
+      name: docker-ce
+      state: latest
+      update_cache: yes
+
+  hosts: all
+

--- a/roles/jool/tasks/main.yml
+++ b/roles/jool/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- hosts: all
+  tasks:
+  - name: install linux-headers
+    apt:
+      name: linux-headers-amd64
+      state: latest
+  - name: limit unstable repository priority
+    template:
+      dest: /etc/apt/preferences.d/limit-unstable
+      src: apt_unstable.j2
+  - name: install git
+    apt:
+      name: git
+      state: latest
+      default_release: unstable
+      update_cache: yes
+  - name: install build-essential
+    apt:
+      name: build-essential
+      state: latest
+  - name: install iptables
+    apt:
+      name: iptables
+      state: latest
+  - name: install dkms
+    apt:
+      name: dkms
+      state: latest

--- a/roles/wireguard/tasks/apt_unstable.j2
+++ b/roles/wireguard/tasks/apt_unstable.j2
@@ -1,0 +1,3 @@
+Package: *
+Pin: release a=unstable
+Pin-Priority: 50

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-task:
+- hosts: all
+  tasks:
   - name: Add debian unstable repository (wireguard)
     apt_repository: 
       repo: deb http://deb.debian.org/debian/ unstable main
@@ -14,5 +15,7 @@ task:
       state: latest
       default_release: unstable
       update_cache: yes
-  hosts: all
- 
+  - name: install iptables
+    apt:
+      name: iptables
+      state: latest

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+task:
+  - name: Add debian unstable repository (wireguard)
+    apt_repository: 
+      repo: deb http://deb.debian.org/debian/ unstable main
+      state: present
+  - name: limit unstable repository priority
+    template:
+      dest: /etc/apt/preferences.d/limit-unstable
+      src: apt_unstable.j2
+  - name: install wireguard
+    apt:
+      name: wireguard
+      state: latest
+      default_release: unstable
+      update_cache: yes
+  hosts: all
+ 

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -23,3 +23,8 @@
     apt:
       name: iptables
       state: latest
+  - name: install dkms
+    apt:
+      name: dkms
+      state: latest
+

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -5,6 +5,10 @@
     apt_repository: 
       repo: deb http://deb.debian.org/debian/ unstable main
       state: present
+  - name: install linux-headers
+    apt:
+      name: linux-headers-amd64
+      state: latest
   - name: limit unstable repository priority
     template:
       dest: /etc/apt/preferences.d/limit-unstable


### PR DESCRIPTION
die babel-gateways werden via ansible aufgesetzt.
Wir brauchen: 
* wireguard
* docker
* babeld

Wir wissen schon, dass wir die docker-omages von dockerhub nutzen wollen. Offen ist, wie die docker container genau gestartet werden. @polybos  Was meinst Du?